### PR TITLE
Jos klever patch plugin constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To improve performance and reduce database load, the plugin uses caching:
 ## Installation
 
 1. **Download the Plugin:**
-   - [Download}(https://github.com/sprucely-designed/mainwp-discord-notifications/releases) the source code ZIP file from the latest release.
+   - [Download](https://github.com/sprucely-designed/mainwp-discord-notifications/releases) the source code ZIP file from the latest release.
 
 2. **Upload the Plugin:**
    - Go to your WordPress dashboard.

--- a/mainwp-discord-notifications.php
+++ b/mainwp-discord-notifications.php
@@ -47,6 +47,8 @@ function sprucely_mwpdn_check_for_plugin_updates() {
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		error_log( 'Discord webhook URL for plugin updates not defined.' );
 		return;
+	} elseif ( ! defined( 'MAINWP_PLUGIN_UPDATES_DISCORD_WEBHOOK_URL' ) ) {
+		define( 'MAINWP_PLUGIN_UPDATES_DISCORD_WEBHOOK_URL', MAINWP_UPDATES_DISCORD_WEBHOOK_URL );
 	}
 	global $wpdb;
 
@@ -112,7 +114,7 @@ function sprucely_mwpdn_check_for_plugin_updates() {
 
 	if ( ! empty( $unique_updates ) ) {
 		foreach ( $unique_updates as $key => $update ) {
-			if ( sprucely_mwpdn_send_discord_message( $update, 'MAINWP_UPDATES_DISCORD_WEBHOOK_URL' ) ) {
+			if ( sprucely_mwpdn_send_discord_message( $update, 'MAINWP_PLUGIN_UPDATES_DISCORD_WEBHOOK_URL' ) ) {
 				$sent_notifications[ $key ] = true; // Mark this notification as sent.
 			}
 			usleep( 500000 ); // Sleep for 0.5 seconds to avoid rate limiting.


### PR DESCRIPTION
After version 1.0 the new constant for the plugin webhook was added in the check, but only the old one was used to send notifications. So if the new one isn't defined, it's now being set to the value of the old one. To send the notification the new constant is used.

Please check the code for correctness and efficiency, as I'm not an experienced developer. I've tested it on my own site and it worked there.

I've also fixed a typo in the readme.