### PR TITLE
Add #developers anchor tag to changelog url

### DIFF
--- a/mainwp-discord-notifications.php
+++ b/mainwp-discord-notifications.php
@@ -372,6 +372,14 @@ function sprucely_mwpdn_send_discord_message( $update, $webhook_url_type ) {
 		$changelog_summary = "**Changelog Summary:** $changelog_summary\n";
 	}
 
+	// Append the anchor tag for the correct changelog tab for plugins on wp.org
+	if ( ! empty( $update['changelog_url'] )  && ( false !== strpos( $update['changelog_url'], 'wordpress.org/plugins' ) ) ) {
+		if ( substr( $update['changelog_url'], - 1 ) !== '/' ) {
+			$update['changelog_url'] .= '/';
+		}
+		$update['changelog_url'] .= '#developers';
+	}
+	
 	// Build the description parts if available.
 	$description   = ! empty( $update['description'] ) ? '**Description:** ' . sprucely_mwpdn_convert_html_to_markdown( $update['description'] ) . "\n" : '';
 	$author        = ! empty( $update['author'] ) ? '**Author:** ' . sprucely_mwpdn_convert_html_to_markdown( $update['author'] ) . "\n" : '';

--- a/mainwp-discord-notifications.php
+++ b/mainwp-discord-notifications.php
@@ -372,14 +372,12 @@ function sprucely_mwpdn_send_discord_message( $update, $webhook_url_type ) {
 		$changelog_summary = "**Changelog Summary:** $changelog_summary\n";
 	}
 
-	// Append the anchor tag for the correct changelog tab for plugins on wp.org
-	if ( ! empty( $update['changelog_url'] )  && ( false !== strpos( $update['changelog_url'], 'wordpress.org/plugins' ) ) ) {
-		if ( substr( $update['changelog_url'], - 1 ) !== '/' ) {
-			$update['changelog_url'] .= '/';
-		}
-		$update['changelog_url'] .= '#developers';
+	// Append the anchor tag for the correct changelog tab for plugins on wp.org.
+	if ( ! empty( $update['changelog_url'] ) && ( false !== strpos( $update['changelog_url'], 'wordpress.org/plugins' ) ) ) {
+		// Ensure the URL ends with a trailing slash then append the anchor.
+		$update['changelog_url'] = trailingslashit( $update['changelog_url'] ) . '#developers';
 	}
-	
+
 	// Build the description parts if available.
 	$description   = ! empty( $update['description'] ) ? '**Description:** ' . sprucely_mwpdn_convert_html_to_markdown( $update['description'] ) . "\n" : '';
 	$author        = ! empty( $update['author'] ) ? '**Author:** ' . sprucely_mwpdn_convert_html_to_markdown( $update['author'] ) . "\n" : '';


### PR DESCRIPTION
Add the #developers anchor tag to the changelog url for plugins on wordpress.org, so the changelog tab is directly opened.