### PR TITLE
Add GitHub Actions workflow to build clean release ZIP

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,16 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Create release ZIP
         run: |
@@ -23,6 +26,6 @@ jobs:
           zip -r mainwp-discord-notifications.zip mainwp-discord-notifications/
 
       - name: Upload ZIP to release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           files: build/mainwp-discord-notifications.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Create release ZIP
         run: |
@@ -26,6 +26,6 @@ jobs:
           zip -r mainwp-discord-notifications.zip mainwp-discord-notifications/
 
       - name: Upload ZIP to release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           files: build/mainwp-discord-notifications.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Build and attach release ZIP
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create release ZIP
+        run: |
+          mkdir -p build/mainwp-discord-notifications
+          rsync -av --exclude='.git' \
+                    --exclude='.github' \
+                    --exclude='build' \
+                    ./ build/mainwp-discord-notifications/
+          cd build
+          zip -r mainwp-discord-notifications.zip mainwp-discord-notifications/
+
+      - name: Upload ZIP to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: build/mainwp-discord-notifications.zip


### PR DESCRIPTION
Closes #14

This adds a GitHub Actions workflow that automatically builds a release ZIP 
when a new release is published. The ZIP contains the plugin files in a folder 
named `mainwp-discord-notifications` (without the version number), which 
prevents folder name mismatch issues when updating via Git Updater or manually.

The workflow:
- Triggers on release published
- Copies plugin files to a correctly named folder
- Excludes `.git` and `.github` directories from the ZIP
- Attaches the ZIP as a release asset automatically