### PR TITLE
Append CHANGELOG.md path for GitHub-hosted plugin changelog URLs

### DIFF
--- a/includes/class-mwpdn-helpers.php
+++ b/includes/class-mwpdn-helpers.php
@@ -272,6 +272,11 @@ class Helpers {
 			$changelog_url = trailingslashit( $changelog_url ) . '#developers';
 		}
 
+		// Append the changelog path for GitHub-hosted plugins.
+		if ( '' !== $changelog_url && preg_match( '#^https://github\.com/[^/]+/[^/]+/?$#i', $changelog_url ) ) {
+			$changelog_url = trailingslashit( $changelog_url ) . 'blob/main/CHANGELOG.md';
+		}
+
 		// Build the description parts if available.
 		$description   = '' !== $description ? '**Description:** ' . $description . "\n" : '';
 		$author        = '' !== $author ? '**Author:** ' . $author . "\n" : '';


### PR DESCRIPTION
Closes #13

Currently, the "View Full Changelog" link in Discord notifications for 
GitHub-hosted plugins points to the plugin's repository homepage, rather 
than the changelog itself.

This fix detects when the changelog URL is a GitHub repository root URL 
and appends `blob/main/CHANGELOG.md` to it, matching the de facto standard 
for changelog files in GitHub-hosted WordPress plugins.

The existing behavior for WordPress.org plugins (appending `#developers`) 
is unchanged.