### PR TITLE
Fix activation hook for scheduled update-check cron (#20)

### DIFF
--- a/includes/class-mwpdn-plugin-updates.php
+++ b/includes/class-mwpdn-plugin-updates.php
@@ -60,7 +60,7 @@ class Plugin_Updates {
 	 * Setup hooks and filters.
 	 */
 	private function setup_hooks() {
-		add_action( 'mainwp_child_plugin_activated', array( $this, 'setup_plugin_update_hook' ) );
+		register_activation_hook( MAINWP_DISCORD_DIR . 'mainwp-discord-notifications.php', array( $this, 'setup_plugin_update_hook' ) );
 		add_action( 'mainwp_cronupdatescheck_action', array( $this, 'check_for_plugin_updates' ) );
 		// Ensure our scheduled hook runs the checker.
 		add_action( 'sprucely_mwpdn_check_for_plugin_updates', array( $this, 'check_for_plugin_updates' ) );

--- a/includes/class-mwpdn-theme-updates.php
+++ b/includes/class-mwpdn-theme-updates.php
@@ -60,7 +60,7 @@ class Theme_Updates {
 	 * Setup hooks and filters.
 	 */
 	private function setup_hooks() {
-		add_action( 'mainwp_child_plugin_activated', array( $this, 'setup_theme_update_hook' ) );
+		register_activation_hook( MAINWP_DISCORD_DIR . 'mainwp-discord-notifications.php', array( $this, 'setup_theme_update_hook' ) );
 		add_action( 'mainwp_cronupdatescheck_action', array( $this, 'check_for_theme_updates' ) );
 		// Ensure our scheduled hook runs the checker.
 		add_action( 'sprucely_mwpdn_check_for_theme_updates', array( $this, 'check_for_theme_updates' ) );


### PR DESCRIPTION
`Plugin_Updates::setup_plugin_update_hook()` and `Theme_Updates::setup_theme_update_hook()` were hooked to `mainwp_child_plugin_activated`, a child-site hook that doesn't fire on the Dashboard where this extension runs. This meant the hourly cron jobs for update checks were likely never scheduled.

Since the plugin requires MainWP to be active (`RequiresPlugins: mainwp`), `register_activation_hook()` on the main plugin file is sufficient and reliable.

For existing installations affected by this bug, simply deactivating and reactivating the plugin will register the cron correctly.

Closes #20